### PR TITLE
Fix get_url docstring entry for status_code

### DIFF
--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -266,7 +266,7 @@ state:
     returned: success
     type: string
     sample: file
-status:
+status_code:
     description: the HTTP status code from the request
     returned: always
     type: int


### PR DESCRIPTION
get_url returns a dict containing the "status_code", not "status". This patch fixes the docstring entry.